### PR TITLE
export flags and rosdep

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -13,6 +13,12 @@
   <depend package="std_srvs"/>
   <depend package="sensor_msgs"/>
   <depend package="image_transport"/>
+
+  <rosdep name="libudev-dev"/>
+
+  <export>
+    <cpp cflags="-I${prefix}/include" lflags="-L${prefix}/lib/i386 -L${prefix}/lib/x86_64" />
+  </export>
 </package>
 
 


### PR DESCRIPTION
With this pullrequest, it is now possible to install the libudev-dev dependency using the rosdep tool by calling:
rosdep install optris_drivers

Additionally, the include and library paths are exported to be used within other ROS nodes directly.
