### PR TITLE
remove duplicated onProcessExit()

### DIFF
--- a/config/14080045.xml
+++ b/config/14080045.xml
@@ -1,23 +1,31 @@
-/usr/share/libirimager/cali/Cali-14080045.xml<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <imager xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <serial>14080045</serial>   <!-- Provide serial number, if you attach more than one camera -->
   <videoformatindex>0</videoformatindex> <!-- index of the used video format (USB enpoint) -->
   <formatspath>/usr/share/libirimager</formatspath>
   <calipath>/usr/share/libirimager/cali</calipath>
+  <!-- Uncomment the following lines to specify user-defined parameters for the desired optic
+       and temperature range. Be aware to specify meaningful parameters.
+       See documentation for further information: http://evocortex.com/libirimager2/html/index.html
+       By default, the first available optic and the first meaningful temperature range are selected.
+  -->
+  <!--
   <fov>33</fov>
   <temperature>
     <min>-20</min>
     <max>100</max>
   </temperature>
-  <framerate>32.0</framerate> <!-- scaled down frame rate, must be less or equal than camera frame rate -->
-  <controller>1</controller>  <!-- 1=HID, 2=UVC -->
-  <outputmode>2</outputmode>  <!-- 1=Energy, 2=Temperature -->
-  <bispectral>0</bispectral>  <!-- 0=only thermal sensor, 1=bispectral technology (only PI200/PI230) -->
-  <average>0</average>        <!-- average callback frames over intermediate frames -->
+  <optics_text></optics_text>
+  -->
+  <framerate>32.0</framerate>             <!-- scaled down frame rate, must be less or equal than camera frame rate -->
+  <bispectral>0</bispectral>              <!-- 0=only thermal sensor, 1=bispectral technology (only PI200/PI230) -->
+  <average>0</average>                    <!-- average callback frames over intermediate frames -->
   <autoflag>
     <enable>1</enable>
     <mininterval>15.0</mininterval>
     <maxinterval>0.0</maxinterval>
   </autoflag>
+  <pifmode>0</pifmode>                    <!-- 0=Image capture (default), 1=Flag control -->
+  <tchipmode>0</tchipmode>                <!-- 0=Floating (default), 1=Auto, 2=Fixed value -->
+  <tchipfixedvalue>40.0</tchipfixedvalue> <!-- Fixed value for tchipmode=2 -->
 </imager>
-

--- a/src/OptrisImager.cpp
+++ b/src/OptrisImager.cpp
@@ -155,4 +155,9 @@ bool OptrisImager::onSetTemperatureRange(TemperatureRange::Request &req, Tempera
   return true;
 }
 
+void OptrisImager::onProcessExit(void* arg)
+{
+  ros::shutdown();
+}
+
 }

--- a/src/OptrisImager.cpp
+++ b/src/OptrisImager.cpp
@@ -161,9 +161,4 @@ bool OptrisImager::onSetTemperatureRange(TemperatureRange::Request &req, Tempera
   return true;
 }
 
-void OptrisImager::onProcessExit(void* arg)
-{
-  ros::shutdown();
-}
-
 }

--- a/src/OptrisImager.cpp
+++ b/src/OptrisImager.cpp
@@ -5,7 +5,9 @@ namespace optris_drivers
 
 OptrisImager::OptrisImager(evo::IRDeviceUVC* dev, evo::IRDeviceParams params)
 {
-  _imager.init(&params, dev->getFrequency(), dev->getWidth(), dev->getHeight());
+  evo::IRLogger::setVerbosity(evo::IRLOG_DEBUG, evo::IRLOG_OFF);
+
+  _imager.init(&params, dev->getFrequency(), dev->getWidth(), dev->getHeight(), dev->controlledViaHID());
   _imager.setClient(this);
 
   _bufferRaw = new unsigned char[_imager.getRawBufferSize()];

--- a/src/OptrisImager.h
+++ b/src/OptrisImager.h
@@ -106,12 +106,6 @@ public:
    */
   bool onSetTemperatureRange(TemperatureRange::Request &req, TemperatureRange::Response &res);
 
-  /**
-   * Callback method from image processing library
-   * @param[in] arg user defined data (passed via process method)
-   */
-  void onProcessExit(void* arg);
-
 private:
 
   evo::IRImager _imager;

--- a/src/OptrisImager.h
+++ b/src/OptrisImager.h
@@ -4,6 +4,7 @@
 #include "libirimager/IRDeviceUVC.h"
 #include "libirimager/IRImager.h"
 #include "libirimager/IRImagerClient.h"
+#include "libirimager/IRLogger.h"
 
 #include "ros/ros.h"
 #include <image_transport/image_transport.h>

--- a/src/OptrisImager.h
+++ b/src/OptrisImager.h
@@ -100,6 +100,12 @@ public:
    */
   bool onSetTemperatureRange(TemperatureRange::Request &req, TemperatureRange::Response &res);
 
+  /**
+   * Callback method from image processing library
+   * @param[in] arg user defined data (passed via process method)
+   */
+  void onProcessExit(void* arg);
+
 private:
 
   evo::IRImager _imager;


### PR DESCRIPTION
Since commit 92f310d `onProcessExit()` is duplicated in `OptrisImager.h` and `OptrisImager.cpp` and doesn't build anymore.