### PR TITLE
add launch file to start ros node with rviz

### DIFF
--- a/launch/optris_drivers_rviz.launch
+++ b/launch/optris_drivers_rviz.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Launch optris_dirvers.launch file and starts rviz with some activated plugins to display the image -->
+<launch>
+    <arg name="rviz_config"     default="$(find optris_drivers)/rviz/optris_drivers.rviz" />
+    <include file="$(find optris_drivers)/launch/optris_drivers.launch" />
+    <node type="rviz" name="rviz" pkg="rviz" args="-d $(arg rviz_config)" />
+</launch>

--- a/rviz/optris_drivers.rviz
+++ b/rviz/optris_drivers.rviz
@@ -1,0 +1,203 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+      Splitter Ratio: 0.5
+    Tree Height: 482
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: Mono
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /optris/image_mono
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Mono
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Class: rviz/Image
+      Enabled: false
+      Image Topic: /optris/image_color
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Color
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: false
+    - Class: rviz/Image
+      Enabled: false
+      Image Topic: /optris/image_rect
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Mono Rect
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: false
+    - Class: rviz/Image
+      Enabled: false
+      Image Topic: /optris/image_rect_color
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Color Rect
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: false
+    - Class: rviz/Image
+      Enabled: false
+      Image Topic: /optris/visible_image_view
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Visible Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: false
+    - Class: rviz/Image
+      Enabled: false
+      Image Topic: /optris/visible_image_view
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Thermal Image View
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: false
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 10
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.6853981018066406
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.7903980016708374
+    Saved: ~
+Window Geometry:
+  Color:
+    collapsed: false
+  Color Rect:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 1025
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Mono:
+    collapsed: false
+  Mono Rect:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000002eb0000026dfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000007c0000026d000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002d4fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000363000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b20000000000000000000000020000073d00000039fc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d000000f5fc0100000003fc000000000000073d000000bf00fffffffa000000050200000006fb000000240054006800650072006d0061006c00200049006d006100670065002000560069006500770100000000ffffffff0000001600fffffffb0000001a00560069007300690062006c006500200049006d0061006700650100000000ffffffff0000001600fffffffb000000140043006f006c006f0072002000520065006300740100000000ffffffff0000001600fffffffb00000012004d006f006e006f002000520065006300740100000000ffffffff0000001600fffffffb0000000a0043006f006c006f00720100000000ffffffff0000001600fffffffb00000008004d006f006e006f0100000000ffffffff0000001600fffffffb0000000a0043006f006c006f00720100000399000003a40000000000000000fb0000000800540069006d006501000000000000045000000000000000000000044c0000026d00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Thermal Image View:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Visible Image:
+    collapsed: false
+  Width: 1853
+  X: 67
+  Y: 27


### PR DESCRIPTION
As developer I want an easy way to see the image data in rviz.

New files:
 - launch/optris_drivers_rviz.launch
 - rviz/optris_dirvers.rviz

The rviz config can be changed by setting the rviz_config parameter. If no rviz_config is given the default optris_drivers.rviz config will be used.

Example usage:
```
roslaunch optris_drivers optris_drivers_rviz.launch rviz_config:="<your awesome rviz config>"
```